### PR TITLE
fix: loosen import related rules

### DIFF
--- a/rules/imports.js
+++ b/rules/imports.js
@@ -138,7 +138,7 @@ module.exports = {
 
     // Ensure consistent use of file extension within the import path
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-    'import/extensions': ['error', 'always', {
+    'import/extensions': ['warn', 'always', {
       js: 'never',
       jsx: 'never',
     }],

--- a/rules/imports.js
+++ b/rules/imports.js
@@ -33,7 +33,7 @@ module.exports = {
 
     // ensure imports point to files/modules that can be resolved
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
-    'import/no-unresolved': ['error', { commonjs: true, caseSensitive: true }],
+    'import/no-unresolved': ['warn', { commonjs: true, caseSensitive: true }],
 
     // ensure named imports coupled with named exports
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md#when-not-to-use-it


### PR DESCRIPTION
> All of our loaders / plugins require webpack, though most have either a loose or no dependency on it

- import/no-unresolved will fail as webpack/* doesn't exist as an explicitly installed dependency

- import/extensions will fail for the same reason, extension can't be determined for something that isn't there.

This change won't effect Travis runs ( no warning thrown ) as we explicitly install webpack 