### PR TITLE
fix: allow dangle for private object members

### DIFF
--- a/rules/stylistic-issues.js
+++ b/rules/stylistic-issues.js
@@ -300,7 +300,7 @@ module.exports = {
 
     // disallow dangling underscores in identifiers
     // http://eslint.org/docs/rules/no-underscore-dangle
-    'no-underscore-dangle': ['error', { allowAfterThis: false }],
+    'no-underscore-dangle': ['error', { allowAfterThis: true }],
 
     // disallow ternary operators when simpler alternatives exist
     // http://eslint.org/docs/rules/no-unneeded-ternary


### PR DESCRIPTION
 - Reasoning: Underscore dangle for private object members is a common and widely accepted convention for indicating private members. This change allows underscore dangle in the case of this._somePrivateMember while preventing the abuse of dangle in any other case.